### PR TITLE
Add Settings page to v0.1 docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- OdometryState has been moved from `robot/status.proto` to `robot/robot.proto`
+- [OdometryState](../v0.1/robot/Robot.md#odometrystate) has been moved from `robot/status.proto` to `robot/robot.proto`
 
 ### Newly Added Endpoints
 

--- a/docs/v0.1/settings.md
+++ b/docs/v0.1/settings.md
@@ -10,20 +10,20 @@ RPC may be used.
 ## Maximum Navigation Speed
 
 The maximum navigation speed of the robot. The robot will accelerate up to this
-speed during navigation
+speed during navigation.
 
 Key | Unit | Min | Max | Default
 ----|------|-----|-----|--------
 `robot-max-vel-x` | meters-per-second | `0.2` | `1.2` | `0.8`
 
-## Wheel Coasting During Idle
+## Unlock Wheels During Idle
 
 Locking state of the wheels when the robot is idle.
 
 True indicates that the wheels will not lock in idle. This allows the user to
 push the robot during this state.
 
-False indicate that the wheels will be locked during idle. This prevents the
+False indicates that the wheels will be locked during idle. This prevents the
 robot from being pushed or from rolling if it is idle on a slope.
 
 Key | Value | Default

--- a/docs/v0.1/settings.md
+++ b/docs/v0.1/settings.md
@@ -1,0 +1,31 @@
+# Settings
+
+Settings are set through the [SetSetting](robot/RobotApiService.md#setsetting)
+RPC. Both key and values are strings so types for each value must be filled as a
+string.
+
+To access the current and available settings, the [SubscribeSettings](robot/RobotApiService.md#subscribesettings)
+RPC may be used.
+
+## Maximum Navigation Speed
+
+The maximum navigation speed of the robot. The robot will accelerate up to this
+speed during navigation
+
+Key | Unit | Min | Max | Default
+----|------|-----|-----|--------
+`robot-max-vel-x` | meters-per-second | `0.2` | `1.2` | `0.8`
+
+## Wheel Coasting During Idle
+
+Locking state of the wheels when the robot is idle.
+
+True indicates that the wheels will not lock in idle. This allows the user to
+push the robot during this state.
+
+False indicate that the wheels will be locked during idle. This prevents the
+robot from being pushed or from rolling if it is idle on a slope.
+
+Key | Value | Default
+----|-------|--------
+`robot-enable-motors-coast-in-idle` | `True` \| `False` | `True`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
           - Settings: v0.1/robot/Settings.md
           - Status: v0.1/robot/Status.md
           - System: v0.1/robot/System.md
+      - Settings: v0.1/settings.md
     - v0.0:
       - Services:
         - RobotAPIService: v0.0/robot/RobotApiService.md


### PR DESCRIPTION
- Add Settings page to v0.1 docs
- Add setting for robot-max-vel-x / robot speed
- Add setting for robot-enable-motors-coast-in-idle / wheel lock
- Add link to OdometryState in changelog


<img width="1295" alt="Screenshot 2025-02-14 at 1 09 45 AM" src="https://github.com/user-attachments/assets/4230484b-32d4-4e20-a1e1-5cc3cfe403a4" />
