### PR TITLE
[PS-65631] Update name "Base API" -> "Robot API"

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-base.api.bearrobotics.ai
+robot.api.bearrobotics.ai

--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ cd robot
 ### Compile & Develop
 The [Robot API Reference](https://bearrobotics-public.github.io/robot/v1.3/resources/Mission/) has documentation for available API.
 
-Client code generation instructions and usage examples for Python can be found [HERE](https://bearrobotics-public.github.io/robot/guides/setup/examples_python/)
+Client code generation instructions and usage examples for Python can be found in our [Setup Guide](https://bearrobotics-public.github.io/robot/guides/setup/examples_python/)
 
 ## License
 
 This project is licensed under the Mozilla Public License version 2.0 (MPLv2). See the [LICENSE](./LICENSE) file for details.
-

--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
-# Bear Base API
+# Bear Robot API
 
 ## Introduction
 Welcome to the Bear's **Base** repository. This repository contains:
 - Protocol Buffers (`.proto` files) defining the API specifications.
-- Documentation for integrating and using the Base API service.
+- Documentation for integrating and using the Robot API service.
 
-The Bear Base API Service is a gRPC-based API for third-party clients to:
+The Bear Robot API Service is a gRPC-based API for third-party clients to:
 - **Send commands** to control the robot base.
 - **Receive status updates** from robot base, such as odometry and battery status.
 - **Retrieve robot information**.
 
-For a comprehensive overview of the API capabilities, refer to the **Public Base API** documentation website. While currently using gRPC, future plans include adding corresponding REST APIs.
-
-See [API Reference](https://bearrobotics-public.github.io/base/)
+For a comprehensive overview of the API capabilities, refer to the [Robot API public docs](https://bearrobotics-public.github.io/base/). While currently using gRPC, future plans include adding corresponding REST APIs.
 
 ---
 
 ## Overview
-The Bear Base API facilitates communication between third-party clients and robots via the gRPC framework. It employs:
+The Bear Robot API facilitates communication between third-party clients and robots via the gRPC framework. It employs:
 - **Unary RPC**: For request/response-type communications.
 - **Server-streaming RPC**: For continuous updates from robots.
 
@@ -55,7 +53,7 @@ cd base
 ```
 
 ### Compile & Develop
-The [API Reference](https://bearrobotics-public.github.io/base/v0/robot/RobotApiService/) has documentation for available API.
+The [Robot API Reference](https://bearrobotics-public.github.io/base/v1.3/resources/Mission/) has documentation for available API.
 
 Client code generation instructions and usage examples for Python can be found [HERE](https://bearrobotics-public.github.io/base/guides/setup/examples_python/)
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Bear Robot API
 
 ## Introduction
-Welcome to the Bear's **Base** repository. This repository contains:
+Welcome to the Bear's **Robot** repository. This repository contains:
 - Protocol Buffers (`.proto` files) defining the API specifications.
 - Documentation for integrating and using the Robot API service.
 
 The Bear Robot API Service is a gRPC-based API for third-party clients to:
-- **Send commands** to control the robot base.
-- **Receive status updates** from robot base, such as odometry and battery status.
+- **Send commands** to control the robot.
+- **Receive status updates** from the robot, such as odometry and battery status.
 - **Retrieve robot information**.
 
-For a comprehensive overview of the API capabilities, refer to the [Robot API public docs](https://bearrobotics-public.github.io/base/). While currently using gRPC, future plans include adding corresponding REST APIs.
+For a comprehensive overview of the API capabilities, refer to the [Robot API public docs](https://bearrobotics-public.github.io/robot/). While currently using gRPC, future plans include adding corresponding REST APIs.
 
 ---
 
@@ -48,14 +48,14 @@ The Bear Robot API facilitates communication between third-party clients and rob
 
 ### Cloning the Repository
 ```bash
-git clone https://github.com/bearrobotics-public/base.git
-cd base
+git clone https://github.com/bearrobotics-public/robot.git
+cd robot
 ```
 
 ### Compile & Develop
-The [Robot API Reference](https://bearrobotics-public.github.io/base/v1.3/resources/Mission/) has documentation for available API.
+The [Robot API Reference](https://bearrobotics-public.github.io/robot/v1.3/resources/Mission/) has documentation for available API.
 
-Client code generation instructions and usage examples for Python can be found [HERE](https://bearrobotics-public.github.io/base/guides/setup/examples_python/)
+Client code generation instructions and usage examples for Python can be found [HERE](https://bearrobotics-public.github.io/robot/guides/setup/examples_python/)
 
 ## License
 

--- a/docs/guides/setup/examples_python.md
+++ b/docs/guides/setup/examples_python.md
@@ -8,7 +8,7 @@ For example, to drive the robot we need the Service from `robot_api_service.prot
 ```bash
 python -m grpc_tools.protoc -I=/path_to_repository/bearrobotics-public/robot/ --python_out=. --grpc_python_out=. bearrobotics/api/v0/robot/robot_api_service.proto
 
-python -m grpc_tools.protoc -I=/path_to_repository/bearrobotics-public/robot/ --python_out=. bearrobotics/api/v0/common/math.proto 
+python -m grpc_tools.protoc -I=/path_to_repository/bearrobotics-public/robot/ --python_out=. bearrobotics/api/v0/common/math.proto
 ```
 
 #### Driving the Robot

--- a/docs/guides/setup/examples_python.md
+++ b/docs/guides/setup/examples_python.md
@@ -6,9 +6,9 @@ Use the `protoc` compiler to generate Python files from your `.proto` files.
 
 For example, to drive the robot we need the Service from `robot_api_service.proto` and Twist message from `math.proto`
 ```bash
-python -m grpc_tools.protoc -I=/path_to_repository/bearrobotics-public/base/ --python_out=. --grpc_python_out=. bearrobotics/api/v0/robot/robot_api_service.proto
+python -m grpc_tools.protoc -I=/path_to_repository/bearrobotics-public/robot/ --python_out=. --grpc_python_out=. bearrobotics/api/v0/robot/robot_api_service.proto
 
-python -m grpc_tools.protoc -I=/path_to_repository/bearrobotics-public/base/ --python_out=. bearrobotics/api/v0/common/math.proto 
+python -m grpc_tools.protoc -I=/path_to_repository/bearrobotics-public/robot/ --python_out=. bearrobotics/api/v0/common/math.proto 
 ```
 
 #### Driving the Robot

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,16 @@
 # Overview
 
-This document describes the gRPC-based Bear Base API Service for third-party clients. The Bear Base API service enables third parties to:
+This document describes the gRPC-based Bear Robot API service for third-party clients. The Bear Robot API service enables third parties to:
 
 1. Send commands to control the robots
 2. Receive status updates from robots (e.g., odometry, battery status)
 3. Retrieve information about the robots
 
-For a detailed list of API capabilities, please navigate through the **API Reference**. Bear Base API uses the open-source gRPC framework. In the future, corresponding REST APIs will be added.
+For a detailed list of API capabilities, please navigate through the [Robot API Reference](v1.3/resources/Mission/). Bear Robot API uses the open-source gRPC framework. In the future, corresponding REST APIs will be added.
 
 ## gRPC
 
-Third-party clients communicate with the Bear Base API service via [gRPC](https://grpc.io/docs/what-is-grpc/introduction). For request/response type communication, [unary RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#unary-rpc) is used. For scenarios where clients need continuous updates from the Bear Base API service, [server streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) is utilized.
+Third-party clients communicate with the Bear Robot API service via [gRPC](https://grpc.io/docs/what-is-grpc/introduction). For request/response type communication, [unary RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#unary-rpc) is used. For scenarios where clients need continuous updates from the Bear Robot API service, [server streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) is utilized.
 
 For server streaming RPCs, all responses include metadata containing a timestamp and a sequence number:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ This document describes the gRPC-based Bear Robot API service for third-party cl
 2. Receive status updates from robots (e.g., odometry, battery status)
 3. Retrieve information about the robots
 
-For a detailed list of API capabilities, please navigate through the [Robot API Reference](v1.3/resources/Mission/). Bear Robot API uses the open-source gRPC framework. In the future, corresponding REST APIs will be added.
+For a detailed list of API capabilities, please navigate through the [Robot API Reference](v1.3/resources/Mission.md/). Bear Robot API uses the open-source gRPC framework. In the future, corresponding REST APIs will be added.
 
 ## gRPC
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Bear Robot API
-site_url: https://base.api.bearrobotics.ai/
+site_url: https://robot.api.bearrobotics.ai/
 copyright: Copyright 2026 Bear Robotics, Inc. All rights reserved.
 theme:
   name: 'material'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Bear Base API
+site_name: Bear Robot API
 site_url: https://base.api.bearrobotics.ai/
 copyright: Copyright 2026 Bear Robotics, Inc. All rights reserved.
 theme:
@@ -36,7 +36,7 @@ markdown_extensions:
 nav:
   - Overview:
     - index.md
-  - API Reference:
+  - Robot API Reference:
     - v1.3:
       - gRPC API:
         - Mission: v1.3/resources/Mission.md


### PR DESCRIPTION
https://bearrobotics.atlassian.net/browse/PS-65631

Verified changes with mkdocs serve

URL migration steps
======
1. Add a CNAME record robot.api.bearrobotics.ai → bearrobotics-public.github.io
2. Merge this change to main
3. Configure base.api.bearrobotics.ai -> robot.api.bearrobotics.ai redirect (if necessary)